### PR TITLE
Change location of the dmd binary (druntime)

### DIFF
--- a/src/do_build_druntime.sh
+++ b/src/do_build_druntime.sh
@@ -12,7 +12,7 @@ echo -e "\tbuilding druntime"
 
 cd $1/druntime
 
-$makecmd DMD=../dmd/src/dmd MODEL=$OUTPUT_MODEL $EXTRA_ARGS -f $makefile auto-tester-build >> ../druntime-build.log 2>&1
+$makecmd DMD=../dmd/generated/*/release/$COMPILER_MODEL/dmd MODEL=$OUTPUT_MODEL $EXTRA_ARGS -f $makefile auto-tester-build >> ../druntime-build.log 2>&1
 if [ $? -ne 0 ]; then
     echo -e "\tdruntime failed to build"
     exit 1


### PR DESCRIPTION
Uses a wildcard instead of the OS name under the assumption that there's only OS directory per OS