### PR TITLE
Remove hard-coded src/dmd executables

### DIFF
--- a/src/do_build_druntime.sh
+++ b/src/do_build_druntime.sh
@@ -21,7 +21,7 @@ if [ $? -ne 0 ]; then
 fi
 
 if [ "$2" != "Win_32" -a "$2" != "Win_32_64" ]; then
-    $makecmd DMD=../dmd/src/dmd MODEL=$OUTPUT_MODEL $EXTRA_ARGS -f $makefile install >> ../druntime-build.log 2>&1
+    $makecmd MODEL=$OUTPUT_MODEL $EXTRA_ARGS -f $makefile install >> ../druntime-build.log 2>&1
     if [ $? -ne 0 ]; then
 	echo -e "\tfailed to install $repo"
 	exit 1

--- a/src/do_build_phobos.sh
+++ b/src/do_build_phobos.sh
@@ -21,7 +21,7 @@ if [ $? -ne 0 ]; then
 fi
 
 if [ "$2" != "Win_32" -a "$2" != "Win_32_64" ]; then
-    $makecmd DMD=../dmd/src/dmd MODEL=$OUTPUT_MODEL $EXTRA_ARGS -f $makefile install >> ../phobos-build.log 2>&1
+    $makecmd MODEL=$OUTPUT_MODEL $EXTRA_ARGS -f $makefile install >> ../phobos-build.log 2>&1
     if [ $? -ne 0 ]; then
 	echo -e "\tfailed to install $repo"
 	exit 1

--- a/src/do_html_phobos.sh
+++ b/src/do_html_phobos.sh
@@ -14,7 +14,6 @@ echo -e "\tgenerating html"
 
 cd $1/phobos
 
-DMD=../dmd/src/dmd
 DOC=../web/2.0
 
 if [ "${2:0:4}" == "Win_" ]; then
@@ -23,7 +22,7 @@ else
     DD=WEBSITE_DIR
 fi
 
-$makecmd DDOC=$DMD $DD=$DOC DMD=$DMD MODEL=$OUTPUT_MODEL -f $makefile html >> ../phobos-html.log 2>&1
+$makecmd DDOC=$DMD $DD=$DOC MODEL=$OUTPUT_MODEL -f $makefile html >> ../phobos-html.log 2>&1
 if [ $? -ne 0 ]; then
     echo -e "\tphobos html generation failed"
     exit 1

--- a/src/do_test_druntime.sh
+++ b/src/do_test_druntime.sh
@@ -16,7 +16,7 @@ if [ "$2" == "stub" ]; then
     exit 0
 fi
 
-$makecmd DMD=../dmd/src/dmd MODEL=$OUTPUT_MODEL $EXTRA_ARGS -f $makefile auto-tester-test >> ../druntime-unittest.log 2>&1
+$makecmd MODEL=$OUTPUT_MODEL $EXTRA_ARGS -f $makefile auto-tester-test >> ../druntime-unittest.log 2>&1
 if [ $? -ne 0 ]; then
     echo -e "\tdruntime unittest failed to build"
     exit 1

--- a/src/do_test_phobos.sh
+++ b/src/do_test_phobos.sh
@@ -19,7 +19,7 @@ case "$2" in
         ;;
 esac
 
-$makecmd DMD=../dmd/src/dmd MODEL=$OUTPUT_MODEL $EXTRA_ARGS -f $makefile auto-tester-test >> ../phobos-unittest.log 2>&1
+$makecmd MODEL=$OUTPUT_MODEL $EXTRA_ARGS -f $makefile auto-tester-test >> ../phobos-unittest.log 2>&1
 if [ $? -ne 0 ]; then
     echo -e "\tphobos tests failed"
     exit 1


### PR DESCRIPTION
Trying to fix https://auto-tester.puremagic.com/show-run.ghtml?projectid=1&runid=2816476&dataid=19934733&isPull=true


`DMD` gets set by default by all these Makefile nowadays and removing it is a lost easier than recreating the `$(DMD_DIR)/generated/$(OS)/release/$(MODEL)/dmd` logic.

See also: https://github.com/dlang/dmd/pull/7135