### PR TITLE
Export HOST_DC during test_dmd

### DIFF
--- a/src/do_test_dmd.sh
+++ b/src/do_test_dmd.sh
@@ -23,6 +23,7 @@ if [[ ! -z "$HOST_DC" && ( "$2" == "Win_32" || "$2" == "Win_32_64" ) ]]; then
     echo "HOST_DC=$HOST_DC" >> $1/dmd-unittest.log 2>&1
 fi
 
+export HOST_DC
 
 echo -e "\ttesting dmd"
 


### PR DESCRIPTION
As the `unittest` blocks within the compiler are compiled during `dmd_test, exposing `HOST_DC` would be very helpful.
Needed for https://github.com/dlang/dmd/pull/6767