### PR TITLE
Expose HOST_DMD for druntime and phobos

### DIFF
--- a/src/do_build_dmd.sh
+++ b/src/do_build_dmd.sh
@@ -8,32 +8,13 @@
 
 . src/setup_env.sh "$2"
 
-if [ "${2:0:7}" == "Darwin_" -o "${2:0:6}" == "Win_32" ]; then
-    BINDIR=bin
-else
-    BINDIR=bin$COMPILER_MODEL
-fi
-
 echo -e "\tbuilding dmd"
 
 top=$PWD
 cd $1/dmd
 
-# expose a prebuilt dmd
-DMDVER=2.079.0
-HOST_DC=`ls -1 $top/release-build/dmd-$DMDVER/*/$BINDIR/dmd$EXE`
-echo "HOST_DC=$HOST_DC" >> ../dmd-build.log 2>&1
-
-if [[ ! -z "$HOST_DC" && ( "$2" == "Win_32" || "$2" == "Win_32_64" ) ]]; then
-    HOST_DC=`cygpath -w $HOST_DC`
-    echo "HOST_DC=$HOST_DC" >> ../dmd-build.log 2>&1
-fi
-
-if [ "$makefile" == "win64.mak" ]; then
-    makefile=win32.mak
-fi
-
-export HOST_DC
+build_step=dmd-build
+. src/host-dmd_env.sh
 
 $makecmd MAKE=$makecmd MODEL=$COMPILER_MODEL $EXTRA_ARGS -f $makefile auto-tester-build >> ../dmd-build.log 2>&1
 if [ $? -ne 0 ]; then

--- a/src/do_build_druntime.sh
+++ b/src/do_build_druntime.sh
@@ -10,7 +10,11 @@
 
 echo -e "\tbuilding druntime"
 
+top=$PWD
 cd $1/druntime
+
+build_step=druntime-build
+. src/host-dmd_env.sh
 
 DMD_PATH=`ls -1 ../dmd/generated/*/release/$COMPILER_MODEL/dmd$EXE`
 

--- a/src/do_build_phobos.sh
+++ b/src/do_build_phobos.sh
@@ -10,7 +10,11 @@
 
 echo -e "\tbuilding phobos"
 
+top=$PWD
 cd $1/phobos
+
+build_step=phobos-build
+. src/host-dmd_env.sh
 
 DMD_PATH=`ls -1 ../dmd/generated/*/release/$COMPILER_MODEL/dmd$EXE`
 

--- a/src/host-dmd_env.sh
+++ b/src/host-dmd_env.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+logfile="../${build_step}.log"
+
+if [ "${2:0:7}" == "Darwin_" -o "${2:0:6}" == "Win_32" ]; then
+    BINDIR=bin
+else
+    BINDIR=bin$COMPILER_MODEL
+fi
+
+# expose a prebuilt dmd
+DMDVER=2.079.0
+HOST_DMD=`ls -1 $top/release-build/dmd-$DMDVER/*/$BINDIR/dmd$EXE`
+echo "HOST_DMD=$HOST_DMD" >> "$logfile" 2>&1
+
+if [[ ! -z "$HOST_DMD" && ( "$2" == "Win_32" || "$2" == "Win_32_64" ) ]]; then
+    HOST_DMD=`cygpath -w $HOST_DMD`
+    echo "HOST_DMD=$HOST_DMD" >> "$logfile" 2>&1
+fi
+
+export HOST_DMD


### PR DESCRIPTION
- HOST_DC has been deprecated for a line time (see https://github.com/dlang/dmd/commit/f20f6b8a5d420aa74238b9a3af9beac146055ae1)
- as we're currently converting the Makefile to pure D build scripts, it would be great to have access to the bootstrap compiler in druntime and phobos